### PR TITLE
[TG-52] fix: unable to load entity.svg

### DIFF
--- a/docs/src/config/resources.js
+++ b/docs/src/config/resources.js
@@ -1,6 +1,8 @@
+const _base_path = "https://uob-comsm0166.github.io/2025-group-16/"
+
 const _path = {
   img: {
-    entity: '../docs/assets/images/entity.svg',
+    entity: 'assets/images/entity.svg',
   },
   sound: {},
 };
@@ -44,11 +46,11 @@ const Resources = {
         Object.fromEntries([
           ...Object.values(_entityVariants.entity).map((fill) => [
             fill,
-            new SVGImage(_path.img.entity, { scale, fill }),
+            new SVGImage(`${_base_path}${_path.img.entity}`, { scale, fill }),
           ]),
           ...Object.entries(_entityVariants.status).map(([status, fill]) => [
             status,
-            new SVGImage(_path.img.entity, { scale, fill }),
+            new SVGImage(`${_base_path}${_path.img.entity}`, { scale, fill }),
           ]),
         ]),
       ]),


### PR DESCRIPTION
#### Summary & Changes

- fix: unable to load entity.svg 
   
   To resolve asset path on github page, add a 'base_path' in resources which will apply github base path on github page and apply local path on local.

#### Jira Link

[View Jira Ticket](https://vivi2393142-0702.atlassian.net/browse/TG-52)
