### PR TITLE
fix: make players stop when welcomeIntro box shows

### DIFF
--- a/docs/src/classes/Player.js
+++ b/docs/src/classes/Player.js
@@ -23,6 +23,7 @@ class Player extends Entity {
     });
 
     this.controls = params.controls;
+    this.isPaused = false;
   }
 
   /** @override */
@@ -30,10 +31,16 @@ class Player extends Entity {
     if (this.status === Constants.EntityStatus.DIED) return;
 
     super.draw();
-    Object.values(Constants.EntityMove).forEach((direction) => {
-      const key = this.controls[direction]?.value;
-      if (keyIsDown(key)) super.move(direction);
-    });
+    if (!this.isPaused){
+      Object.values(Constants.EntityMove).forEach((direction) => {
+        const key = this.controls[direction]?.value;
+        if (keyIsDown(key)) super.move(direction);
+      });
+    }
+  }
+
+  setPauseState(pauseState){
+    this.isPaused = pauseState;
   }
 
   keyPressed(entities, onDie) {


### PR DESCRIPTION
#### Summary

fix: make characters stop moving when the intro box pop out on Welcome page

#### Changes

<!-- List the key changes in this PR -->

#### Jira Link

[View Jira Ticket](https://vivi2393142-0702.atlassian.net/browse/<!-- Replace this comment with your TG-XX number -->)
