### PR TITLE
fix: wrong text style on WelcomeIntro

### DIFF
--- a/docs/src/pages/Welcome.js
+++ b/docs/src/pages/Welcome.js
@@ -170,10 +170,12 @@ class Welcome extends BasePage {
   }
 
   drawIntroStroke(position) {
+    push();
     noFill();
     stroke(0);
     strokeWeight(3);
     rect(position.x, position.y, position.w, position.h);
+    pop();
   }
 
   createIntroText(position) {

--- a/docs/src/pages/maps/MapIntro1.js
+++ b/docs/src/pages/maps/MapIntro1.js
@@ -82,12 +82,14 @@ class MapIntro1 extends BaseMapIntro {
       pop();
 
       // Draw "ROBOT" labels under each enemyrobot
+      push();
       fill(0);
       noStroke();
       textSize(18);
       textStyle(BOLD);
       textAlign(CENTER, CENTER);
       text('ROBOT', robot.x + 50, robot.y + 130);
+      pop();
     });
 
     // Then draw player robot on top
@@ -104,6 +106,7 @@ class MapIntro1 extends BaseMapIntro {
     const boxY = height - boxHeight - 3;
     // const borderRadius = 20;
 
+    push();
     fill(255, 250, 240);
     stroke(0);
     strokeWeight(2);
@@ -123,6 +126,7 @@ class MapIntro1 extends BaseMapIntro {
     textSize(35);
     textAlign(RIGHT, CENTER);
     text('Press →', width - 25, height - 25);
+    pop();
   }
 
   /** @override */


### PR DESCRIPTION
#### Summary & Changes

- fix: wrong text style on WelcomeIntro

#### Description

- Reason: text in `Welcome` and `MapIntro1` didn't reset text style after drawing, which cause text style get wrong on `WelcomeIntro`
- Fix: add `push` and `pop` on this two page to ensure text style reset after these pages