### PR TITLE
[TG-94] fix: wrong sound when hit

### DIFF
--- a/docs/src/classes/Entity.js
+++ b/docs/src/classes/Entity.js
@@ -119,7 +119,7 @@ class Entity {
     };
     for (const entity of entities) {
       const isMe = entity.type === this.type && entity.idx === this.idx;
-      if (!isMe) {
+      if (!isMe && entity.status !== Constants.EntityStatus.DIED) {
         const isKnockedDown = checkKnockedDown(this, entity);
         if (isKnockedDown) hitEntities[entity.type].push(entity);
       }


### PR DESCRIPTION
#### Summary & Changes

- fix: wrong sound when hit

#### Description

- Reason: didn't check if entity is alive or not when `checkKnockedDown` is called, which leads to hit died robot every time
- Fix: check entity status before calling `checkKnockedDown`

#### Jira Link

[View Jira Ticket](https://vivi2393142-0702.atlassian.net/browse/TG-94)
